### PR TITLE
[Feat] Add Places support for Lunar Phase Widget

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,14 +22,10 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments += mapOf(
-                    "room.schemaLocation" to "$projectDir/schemas",
-                    "room.incremental" to "true",
-                    "room.expandProjection" to "true"
-                )
-            }
+        ksp {
+            arg("room.schemaLocation", "$projectDir/schemas")
+            arg("room.incremental", "true")
+            arg("room.expandProjection", "true")
         }
     }
 

--- a/app/src/main/java/dev/mslalith/focuslauncher/data/models/BottomSheetContentType.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/data/models/BottomSheetContentType.kt
@@ -14,5 +14,5 @@ sealed class BottomSheetContentType {
 enum class WidgetType(val text: String) {
     CLOCK(text = "Clock"),
     LUNAR_PHASE(text = "Lunar Phase"),
-    QUOTES(text = "Quotes")
+    // QUOTES(text = "Quotes")
 }

--- a/app/src/main/java/dev/mslalith/focuslauncher/data/models/Screen.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/data/models/Screen.kt
@@ -4,4 +4,5 @@ sealed class Screen(val id: String) {
     object Launcher : Screen("screen_launcher")
     object EditFavorites : Screen("screen_edit_favorites")
     object HideApps : Screen("screen_hide_apps")
+    object PickPlaceForLunarPhase: Screen("screen_pick_place_for_lunar_phase")
 }

--- a/app/src/main/java/dev/mslalith/focuslauncher/data/models/Screen.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/data/models/Screen.kt
@@ -4,5 +4,5 @@ sealed class Screen(val id: String) {
     object Launcher : Screen("screen_launcher")
     object EditFavorites : Screen("screen_edit_favorites")
     object HideApps : Screen("screen_hide_apps")
-    object PickPlaceForLunarPhase: Screen("screen_pick_place_for_lunar_phase")
+    object PickPlaceForLunarPhase : Screen("screen_pick_place_for_lunar_phase")
 }

--- a/app/src/main/java/dev/mslalith/focuslauncher/extensions/UtilityExtensions.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/extensions/UtilityExtensions.kt
@@ -40,7 +40,9 @@ fun ZonedDateTime.inShortReadableFormat(): String {
     return "$day$daySuffix $monthReadable"
 }
 
-fun LocalDateTime.inShortReadableFormat(): String {
+fun LocalDateTime.inShortReadableFormat(
+    shortMonthName: Boolean = false
+): String {
     val daySuffix = when (dayOfMonth) {
         1, 21, 31 -> "st"
         2, 22 -> "nd"
@@ -51,6 +53,7 @@ fun LocalDateTime.inShortReadableFormat(): String {
         month.toString()
             .lowercase(Locale.getDefault())
             .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+            .run { if (shortMonthName) take(3) else this }
 
     return "$dayOfMonth$daySuffix $monthReadable"
 }

--- a/app/src/main/java/dev/mslalith/focuslauncher/extensions/UtilityExtensions.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/extensions/UtilityExtensions.kt
@@ -2,8 +2,6 @@ package dev.mslalith.focuslauncher.extensions
 
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Handler
-import android.os.Looper
 import dev.mslalith.focuslauncher.data.model.App
 import dev.mslalith.focuslauncher.data.model.AppWithIcon
 import kotlinx.datetime.Clock
@@ -14,21 +12,6 @@ import kotlinx.datetime.toLocalDateTime
 import java.time.Month
 import java.time.ZonedDateTime
 import java.util.Locale
-
-fun runAfter(delayMillis: Long, action: () -> Unit) = Handler(Looper.getMainLooper()).postDelayed(action, delayMillis)
-
-fun waitAndRunAfter(
-    startTime: Long,
-    minTime: Long = 2000L,
-    action: () -> Unit,
-) {
-    val elapsedTime = System.currentTimeMillis() - startTime
-    val waitTimeMillis = if (elapsedTime < minTime) minTime - elapsedTime else 0
-    runAfter(
-        delayMillis = waitTimeMillis,
-        action = action,
-    )
-}
 
 fun Instant.formatToTime(): String {
     return toLocalDateTime(TimeZone.currentSystemDefault()).run {
@@ -73,6 +56,7 @@ fun LocalDateTime.inShortReadableFormat(): String {
 }
 
 fun Double.asPercent(precision: Int = 2) = "%.${precision}f".format(this) + "%"
+fun Double.limitDecimals(precision: Int = 2) = "%.${precision}f".format(this)
 
 fun Char.isAlphabet() = when (code) {
     in 65..90 -> true

--- a/app/src/main/java/dev/mslalith/focuslauncher/navigator/AppNavigator.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/navigator/AppNavigator.kt
@@ -11,6 +11,7 @@ import dev.mslalith.focuslauncher.data.providers.LocalNavController
 import dev.mslalith.focuslauncher.ui.screens.EditFavoritesScreen
 import dev.mslalith.focuslauncher.ui.screens.HideAppsScreen
 import dev.mslalith.focuslauncher.ui.screens.LauncherScreen
+import dev.mslalith.focuslauncher.ui.screens.PickPlaceForLunarPhaseScreen
 
 @Composable
 fun AppNavigator() {
@@ -23,6 +24,7 @@ fun AppNavigator() {
         launcherScreen()
         editFavoritesScreen()
         hideAppsScreen()
+        pickPlaceForLunarPhase()
     }
 }
 
@@ -51,6 +53,14 @@ private fun NavGraphBuilder.hideAppsScreen() {
     composable(Screen.HideApps.id) {
         HideAppsScreen(
             appsViewModel = hiltViewModel(it),
+        )
+    }
+}
+
+private fun NavGraphBuilder.pickPlaceForLunarPhase() {
+    composable(Screen.PickPlaceForLunarPhase.id) {
+        PickPlaceForLunarPhaseScreen(
+            settingsViewModel = hiltViewModel(it),
         )
     }
 }

--- a/app/src/main/java/dev/mslalith/focuslauncher/navigator/AppNavigator.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/navigator/AppNavigator.kt
@@ -60,7 +60,7 @@ private fun NavGraphBuilder.hideAppsScreen() {
 private fun NavGraphBuilder.pickPlaceForLunarPhase() {
     composable(Screen.PickPlaceForLunarPhase.id) {
         PickPlaceForLunarPhaseScreen(
-            settingsViewModel = hiltViewModel(it),
+            pickPlaceViewModel = hiltViewModel(it)
         )
     }
 }

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/PickPlaceForLunarPhaseScreen.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/PickPlaceForLunarPhaseScreen.kt
@@ -1,0 +1,42 @@
+package dev.mslalith.focuslauncher.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.mslalith.focuslauncher.data.providers.LocalNavController
+import dev.mslalith.focuslauncher.ui.viewmodels.SettingsViewModel
+import dev.mslalith.focuslauncher.ui.views.AppBarWithBackIcon
+
+@Composable
+fun PickPlaceForLunarPhaseScreen(
+    settingsViewModel: SettingsViewModel
+) {
+    val navController = LocalNavController.current
+    val scaffoldState = rememberScaffoldState()
+
+    fun goBack() = navController.popBackStack()
+
+    Scaffold(
+        scaffoldState = scaffoldState,
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding(),
+        topBar = {
+            AppBarWithBackIcon(
+                title = "Pick a Place",
+                onBackPressed = { goBack() }
+            )
+        },
+    ) {
+        Box(modifier = Modifier.fillMaxSize().padding(it)) {
+            Text(text = "Pick a Place")
+        }
+    }
+}

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/PickPlaceForLunarPhaseScreen.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/PickPlaceForLunarPhaseScreen.kt
@@ -1,27 +1,40 @@
 package dev.mslalith.focuslauncher.ui.screens
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ListItem
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import dev.mslalith.focuslauncher.data.model.places.City
 import dev.mslalith.focuslauncher.data.providers.LocalNavController
-import dev.mslalith.focuslauncher.ui.viewmodels.SettingsViewModel
+import dev.mslalith.focuslauncher.ui.viewmodels.PickPlaceViewModel
 import dev.mslalith.focuslauncher.ui.views.AppBarWithBackIcon
+import dev.mslalith.focuslauncher.ui.views.shared.SearchField
 
 @Composable
 fun PickPlaceForLunarPhaseScreen(
-    settingsViewModel: SettingsViewModel
+    pickPlaceViewModel: PickPlaceViewModel,
 ) {
     val navController = LocalNavController.current
     val scaffoldState = rememberScaffoldState()
 
     fun goBack() = navController.popBackStack()
+
+    LaunchedEffect(key1 = Unit) {
+        pickPlaceViewModel.fetchCities()
+    }
 
     Scaffold(
         scaffoldState = scaffoldState,
@@ -34,9 +47,44 @@ fun PickPlaceForLunarPhaseScreen(
                 onBackPressed = { goBack() }
             )
         },
-    ) {
-        Box(modifier = Modifier.fillMaxSize().padding(it)) {
-            Text(text = "Pick a Place")
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        ) {
+            SearchField(
+                placeholder = "Search city...",
+                query = pickPlaceViewModel.searchQueryStateFlow.collectAsState().value,
+                onQueryChange = pickPlaceViewModel::updateSearch
+            )
+            CitiesList(
+                cities = pickPlaceViewModel.citiesStateFlow.collectAsState().value,
+                onCitySelected = { city ->
+                    pickPlaceViewModel.pickCity(city) { goBack() }
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun CitiesList(
+    cities: List<City>,
+    onCitySelected: (City) -> Unit
+) {
+    LazyColumn {
+        items(
+            items = cities,
+            key = { it.id }
+        ) { city ->
+            ListItem(
+                text = {
+                    Text(text = city.name)
+                },
+                modifier = Modifier.clickable { onCitySelected(city) }
+            )
         }
     }
 }

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/PickPlaceForLunarPhaseScreen.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/PickPlaceForLunarPhaseScreen.kt
@@ -33,6 +33,7 @@ fun PickPlaceForLunarPhaseScreen(
     fun goBack() = navController.popBackStack()
 
     LaunchedEffect(key1 = Unit) {
+        pickPlaceViewModel.updateSearch("")
         pickPlaceViewModel.fetchCities()
     }
 

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/pages/AppDrawerPage.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/pages/AppDrawerPage.kt
@@ -70,6 +70,7 @@ import dev.mslalith.focuslauncher.extensions.launchApp
 import dev.mslalith.focuslauncher.extensions.toAppWithIconList
 import dev.mslalith.focuslauncher.ui.viewmodels.AppsViewModel
 import dev.mslalith.focuslauncher.ui.viewmodels.SettingsViewModel
+import dev.mslalith.focuslauncher.ui.views.shared.SearchField
 
 private val ITEM_START_PADDING = 24.dp
 private val ITEM_END_PADDING = 8.dp
@@ -91,6 +92,8 @@ fun AppDrawerPage(
     val viewManager = LocalLauncherViewManager.current
 
     val appDrawerViewType by settingsViewModel.appDrawerViewTypeStateFlow.collectAsState()
+    val showSearchBar by settingsViewModel.searchBarVisibilityStateFlow.collectAsState()
+    val searchAppQuery by appsViewModel.searchAppStateFlow.collectAsState()
 
     fun onAppClick(app: AppWithIcon) {
         focusManager.clearFocus()
@@ -137,10 +140,13 @@ fun AppDrawerPage(
             ListFadeOutEdgeGradient(position = Position.BOTTOM)
         }
 
-        SearchAppField(
-            appsViewModel = appsViewModel,
-            settingsViewModel = settingsViewModel,
-        )
+        AnimatedVisibility(visible = showSearchBar) {
+            SearchField(
+                placeholder = "Search app...",
+                query = searchAppQuery,
+                onQueryChange = appsViewModel::searchAppQuery
+            )
+        }
     }
 }
 

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/pages/HomePage.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/pages/HomePage.kt
@@ -78,6 +78,7 @@ import dev.mslalith.focuslauncher.ui.viewmodels.WidgetsViewModel
 import dev.mslalith.focuslauncher.ui.views.BackPressHandler
 import dev.mslalith.focuslauncher.ui.views.IconType
 import dev.mslalith.focuslauncher.ui.views.RoundIcon
+import dev.mslalith.focuslauncher.ui.views.dialogs.LunarPhaseDetailsDialog
 import dev.mslalith.focuslauncher.ui.views.widgets.ClockWidget
 import dev.mslalith.focuslauncher.ui.views.widgets.LunarCalendar
 import dev.mslalith.focuslauncher.ui.views.widgets.QuoteForYou
@@ -108,6 +109,7 @@ fun HomePage(
 ) {
     val context = LocalContext.current
     val enablePullDownNotificationShade by settingsViewModel.notificationShadeStateFlow.collectAsState()
+    val showMoonCalendarDetailsDialog by widgetsViewModel.showMoonCalendarDetailsDialogStateFlow.collectAsState()
 
     CompositionLocalProvider(LocalHomePadding provides HomePadding()) {
         val contentPaddingValues = LocalHomePadding.current.contentPaddingValues
@@ -132,6 +134,7 @@ fun HomePage(
                 SpacedMoonCalendar(
                     settingsViewModel = settingsViewModel,
                     widgetsViewModel = widgetsViewModel,
+                    onMoonCalendarClick = widgetsViewModel::showMoonCalendarDetailsDialog
                 )
                 Box(modifier = Modifier.weight(1f)) {
                     DecoratedQuote(
@@ -150,6 +153,13 @@ fun HomePage(
             }
         }
     }
+
+    if (showMoonCalendarDetailsDialog) {
+        LunarPhaseDetailsDialog(
+            widgetsViewModel = widgetsViewModel,
+            onClose = widgetsViewModel::hideMoonCalendarDetailsDialog
+        )
+    }
 }
 
 @Composable
@@ -157,6 +167,7 @@ private fun SpacedMoonCalendar(
     modifier: Modifier = Modifier,
     settingsViewModel: SettingsViewModel,
     widgetsViewModel: WidgetsViewModel,
+    onMoonCalendarClick: () -> Unit
 ) {
     val homePadding = LocalHomePadding.current
     val startPadding = homePadding.contentPaddingValues.calculateStartPadding(LayoutDirection.Ltr)
@@ -170,12 +181,13 @@ private fun SpacedMoonCalendar(
             widgetsViewModel = widgetsViewModel,
             iconSize = iconSize,
             horizontalPadding = startOffsetPadding,
+            onClick = onMoonCalendarClick
         )
     }
 }
 
 @Composable
-fun DecoratedQuote(
+private fun DecoratedQuote(
     modifier: Modifier = Modifier,
     settingsViewModel: SettingsViewModel,
     widgetsViewModel: WidgetsViewModel,

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/pages/SettingsPage.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/screens/pages/SettingsPage.kt
@@ -41,7 +41,6 @@ import dev.mslalith.focuslauncher.data.models.AppDrawerSettingsProperties
 import dev.mslalith.focuslauncher.data.models.BottomSheetContentType
 import dev.mslalith.focuslauncher.data.models.ClockSettingsProperties
 import dev.mslalith.focuslauncher.data.models.LunarPhaseSettingsProperties
-import dev.mslalith.focuslauncher.data.models.QuotesSettingsProperties
 import dev.mslalith.focuslauncher.data.models.Screen
 import dev.mslalith.focuslauncher.data.models.WidgetType
 import dev.mslalith.focuslauncher.data.providers.LocalLauncherViewManager
@@ -243,14 +242,14 @@ private fun Widgets(
                                 ),
                             )
                         }
-                        WidgetType.QUOTES -> onWidgetTypeClick {
-                            BottomSheetContentType.Widgets.Quotes(
-                                properties = QuotesSettingsProperties(
-                                    widgetsViewModel = widgetsViewModel,
-                                    settingsViewModel = settingsViewModel,
-                                ),
-                            )
-                        }
+                        // WidgetType.QUOTES -> onWidgetTypeClick {
+                        //     BottomSheetContentType.Widgets.Quotes(
+                        //         properties = QuotesSettingsProperties(
+                        //             widgetsViewModel = widgetsViewModel,
+                        //             settingsViewModel = settingsViewModel,
+                        //         ),
+                        //     )
+                        // }
                     }
                 },
             )

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/AppsViewModel.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/AppsViewModel.kt
@@ -14,6 +14,7 @@ import dev.mslalith.focuslauncher.extensions.appDrawerApps
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -33,13 +34,16 @@ class AppsViewModel @Inject constructor(
     /**
      * Search Apps
      */
-    private val searchAppFlow = MutableStateFlow("")
+    private val _searchAppStateFlow = MutableStateFlow("")
+    val searchAppStateFlow: StateFlow<String>
+        get() = _searchAppStateFlow
+
     fun searchAppQuery(query: String) {
-        searchAppFlow.value = query
+        _searchAppStateFlow.value = query
     }
 
     val isSearchQueryEmpty: Flow<Boolean>
-        get() = searchAppFlow.map { it.isEmpty() }
+        get() = _searchAppStateFlow.map { it.isEmpty() }
 
     /**
      * Show Hidden Apps In Favorites
@@ -62,7 +66,7 @@ class AppsViewModel @Inject constructor(
     private val appDrawerAppsFlow: Flow<List<App>>
         get() = appDrawerRepo.allAppsFlow.combine(hiddenAppsRepo.onlyHiddenAppsFlow) { allApps, hiddenApps ->
             allApps - hiddenApps.toSet()
-        }.combine(searchAppFlow) { filteredApps, query ->
+        }.combine(_searchAppStateFlow) { filteredApps, query ->
             when {
                 query.isNotEmpty() -> filteredApps.filter {
                     it.name.startsWith(

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/PickPlaceViewModel.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/PickPlaceViewModel.kt
@@ -29,7 +29,7 @@ class PickPlaceViewModel @Inject constructor(
     val searchQueryStateFlow: StateFlow<String>
         get() = _searchQueryStateFlow
 
-    val citiesStateFlow = placesRepo.citiesStateFlow.combine(_searchQueryStateFlow) { cities, query ->
+    val citiesStateFlow = placesRepo.citiesFlow.combine(_searchQueryStateFlow) { cities, query ->
         if (query.isEmpty()) return@combine cities
         cities.filter { it.name.contains(query, ignoreCase = true) }
     }.withinScope(emptyList())

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/PickPlaceViewModel.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/PickPlaceViewModel.kt
@@ -1,0 +1,71 @@
+package dev.mslalith.focuslauncher.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.mslalith.focuslauncher.data.model.places.City
+import dev.mslalith.focuslauncher.data.repository.PlacesRepo
+import dev.mslalith.focuslauncher.data.repository.settings.LunarPhaseSettingsRepo
+import dev.mslalith.focuslauncher.data.utils.AppCoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+class PickPlaceViewModel @Inject constructor(
+    private val placesRepo: PlacesRepo,
+    private val lunarPhaseSettingsRepo: LunarPhaseSettingsRepo,
+    private val appCoroutineDispatcher: AppCoroutineDispatcher
+) : ViewModel() {
+
+    private val _searchQueryStateFlow = MutableStateFlow("")
+    val searchQueryStateFlow: StateFlow<String>
+        get() = _searchQueryStateFlow
+
+    val citiesStateFlow = placesRepo.citiesStateFlow.combine(_searchQueryStateFlow) { cities, query ->
+        if (query.isEmpty()) return@combine cities
+        cities.filter { it.name.contains(query, ignoreCase = true) }
+    }.withinScope(emptyList())
+
+    private val _pickedCity = MutableStateFlow<City?>(null)
+    val pickedCity: StateFlow<City?>
+        get() = _pickedCity
+
+    fun fetchCities() {
+        launch { placesRepo.fetchCities() }
+    }
+
+    fun updateSearch(query: String) {
+        _searchQueryStateFlow.value = query
+    }
+
+    fun pickCity(
+        city: City,
+        onPicked: () -> Unit
+    ) {
+        _pickedCity.value = city
+        launch {
+            lunarPhaseSettingsRepo.updatePlace(city)
+            withContext(appCoroutineDispatcher.main) { onPicked() }
+        }
+    }
+
+    private fun launch(
+        run: suspend CoroutineScope.() -> Unit
+    ) = viewModelScope.launch(appCoroutineDispatcher.io) { run() }
+
+    private fun <T> Flow<T>.withinScope(
+        initialValue: T
+    ) = stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Lazily,
+        initialValue = initialValue
+    )
+}

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/SettingsViewModel.kt
@@ -23,6 +23,7 @@ import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.General
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.General.DEFAULT_IS_DEFAULT_LAUNCHER
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.General.DEFAULT_NOTIFICATION_SHADE
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.General.DEFAULT_STATUS_BAR
+import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_CURRENT_PLACE
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_SHOW_ILLUMINATION_PERCENT
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_SHOW_LUNAR_PHASE
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_SHOW_UPCOMING_PHASE_DETAILS
@@ -87,6 +88,7 @@ class SettingsViewModel @Inject constructor(
     val showLunarPhaseStateFlow = lunarPhaseSettingsRepo.showLunarPhaseFlow.withinScope(DEFAULT_SHOW_LUNAR_PHASE)
     val showIlluminationPercentStateFlow = lunarPhaseSettingsRepo.showIlluminationPercentFlow.withinScope(DEFAULT_SHOW_ILLUMINATION_PERCENT)
     val showUpcomingPhaseDetailsStateFlow = lunarPhaseSettingsRepo.showUpcomingPhaseDetailsFlow.withinScope(DEFAULT_SHOW_UPCOMING_PHASE_DETAILS)
+    val currentPlaceStateFlow = lunarPhaseSettingsRepo.currentPlaceFlow.withinScope(DEFAULT_CURRENT_PLACE)
 
     fun toggleShowLunarPhase() { launch { lunarPhaseSettingsRepo.toggleShowLunarPhase() } }
     fun toggleShowIlluminationPercent() { launch { lunarPhaseSettingsRepo.toggleShowIlluminationPercent() } }

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/WidgetsViewModel.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/viewmodels/WidgetsViewModel.kt
@@ -13,7 +13,9 @@ import dev.mslalith.focuslauncher.data.utils.AppCoroutineDispatcher
 import dev.mslalith.focuslauncher.extensions.formatToTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -51,6 +53,18 @@ class WidgetsViewModel @Inject constructor(
      */
     val lunarPhaseDetailsStateFlow = lunarPhaseRepo.lunarPhaseDetailsStateFlow.withinScope(INITIAL_LUNAR_PHASE_DETAILS_STATE)
     val upcomingLunarPhaseStateFlow = lunarPhaseRepo.upcomingLunarPhaseStateFlow.withinScope(INITIAL_UPCOMING_LUNAR_PHASE_STATE)
+
+    private val _showMoonCalendarDetailsDialogStateFlow = MutableStateFlow(false)
+    val showMoonCalendarDetailsDialogStateFlow: StateFlow<Boolean>
+        get() = _showMoonCalendarDetailsDialogStateFlow
+
+    fun showMoonCalendarDetailsDialog() {
+        _showMoonCalendarDetailsDialogStateFlow.value = true
+    }
+
+    fun hideMoonCalendarDetailsDialog() {
+        _showMoonCalendarDetailsDialogStateFlow.value = false
+    }
 
     /**
      * Quotes

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/SettingPreference.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/SettingPreference.kt
@@ -185,6 +185,9 @@ fun SettingsSelectableItem(
     val textColor by animateColorAsState(
         targetValue = if (disabled) onBackgroundColor.copy(alpha = 0.4f) else onBackgroundColor,
     )
+    val subTextColor by animateColorAsState(
+        targetValue = if (disabled) onBackgroundColor.copy(alpha = 0.4f) else onBackgroundColor.copy(alpha = 0.6f),
+    )
 
     Column(
         modifier = modifier
@@ -228,7 +231,7 @@ fun SettingsSelectableItem(
                 Text(
                     text = it,
                     style = TextStyle(
-                        color = textColor.copy(alpha = 0.6f),
+                        color = subTextColor,
                         fontSize = 14.sp,
                     )
                 )

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/bottomsheets/settings/LunarPhaseSettingsSheet.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/bottomsheets/settings/LunarPhaseSettingsSheet.kt
@@ -41,6 +41,7 @@ fun LunarPhaseSettingsSheet(
         val showLunarPhase by settingsViewModel.showLunarPhaseStateFlow.collectAsState()
         val showIlluminationPercent by settingsViewModel.showIlluminationPercentStateFlow.collectAsState()
         val showUpcomingPhaseDetails by settingsViewModel.showUpcomingPhaseDetailsStateFlow.collectAsState()
+        val currentPlace by settingsViewModel.currentPlaceStateFlow.collectAsState()
 
         Column {
             PreviewLunarCalendar(
@@ -67,7 +68,7 @@ fun LunarPhaseSettingsSheet(
             )
             SettingsSelectableItem(
                 text = "Current Place",
-                subText = "India",
+                subText = currentPlace.name,
                 disabled = !showLunarPhase,
                 onClick = { navigateTo(Screen.PickPlaceForLunarPhase) }
             )

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/bottomsheets/settings/LunarPhaseSettingsSheet.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/bottomsheets/settings/LunarPhaseSettingsSheet.kt
@@ -20,9 +20,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.mslalith.focuslauncher.data.models.LunarPhaseSettingsProperties
+import dev.mslalith.focuslauncher.data.models.Screen
+import dev.mslalith.focuslauncher.data.providers.LocalNavController
 import dev.mslalith.focuslauncher.extensions.VerticalSpacer
 import dev.mslalith.focuslauncher.ui.viewmodels.SettingsViewModel
 import dev.mslalith.focuslauncher.ui.viewmodels.WidgetsViewModel
+import dev.mslalith.focuslauncher.ui.views.SettingsSelectableItem
 import dev.mslalith.focuslauncher.ui.views.SettingsSelectableSwitchItem
 import dev.mslalith.focuslauncher.ui.views.widgets.LunarCalendar
 
@@ -30,6 +33,10 @@ import dev.mslalith.focuslauncher.ui.views.widgets.LunarCalendar
 fun LunarPhaseSettingsSheet(
     properties: LunarPhaseSettingsProperties,
 ) {
+    val navController = LocalNavController.current
+
+    fun navigateTo(screen: Screen) = navController.navigate(screen.id)
+
     properties.apply {
         val showLunarPhase by settingsViewModel.showLunarPhaseStateFlow.collectAsState()
         val showIlluminationPercent by settingsViewModel.showIlluminationPercentStateFlow.collectAsState()
@@ -57,6 +64,12 @@ fun LunarPhaseSettingsSheet(
                 checked = showUpcomingPhaseDetails,
                 disabled = !showLunarPhase,
                 onClick = { settingsViewModel.toggleShowUpcomingPhaseDetails() }
+            )
+            SettingsSelectableItem(
+                text = "Current Place",
+                subText = "India",
+                disabled = !showLunarPhase,
+                onClick = { navigateTo(Screen.PickPlaceForLunarPhase) }
             )
             VerticalSpacer(spacing = bottomSpacing)
         }

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/bottomsheets/settings/LunarPhaseSettingsSheet.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/bottomsheets/settings/LunarPhaseSettingsSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.mslalith.focuslauncher.data.models.LunarPhaseSettingsProperties
 import dev.mslalith.focuslauncher.extensions.VerticalSpacer
@@ -67,9 +68,9 @@ private fun PreviewLunarCalendar(
     settingsViewModel: SettingsViewModel,
     widgetsViewModel: WidgetsViewModel,
     showLunarPhase: Boolean,
+    horizontalPadding: Dp = 24.dp,
 ) {
     val height = 74.dp
-    val horizontalPadding = 24.dp
 
     Crossfade(
         targetState = showLunarPhase,

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/dialogs/LunarPhaseDetailsDialog.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/dialogs/LunarPhaseDetailsDialog.kt
@@ -1,12 +1,15 @@
 package dev.mslalith.focuslauncher.ui.views.dialogs
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
@@ -26,11 +29,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import dev.mslalith.focuslauncher.data.model.LunarPhaseDetails
+import dev.mslalith.focuslauncher.data.model.NextPhaseDetails
 import dev.mslalith.focuslauncher.data.model.getOrNull
 import dev.mslalith.focuslauncher.extensions.FillSpacer
 import dev.mslalith.focuslauncher.extensions.HorizontalSpacer
 import dev.mslalith.focuslauncher.extensions.VerticalSpacer
 import dev.mslalith.focuslauncher.extensions.asPercent
+import dev.mslalith.focuslauncher.extensions.inShortReadableFormat
 import dev.mslalith.focuslauncher.extensions.limitDecimals
 import dev.mslalith.focuslauncher.ui.viewmodels.WidgetsViewModel
 import dev.mslalith.focuslauncher.ui.views.widgets.LunarPhaseMoonIcon
@@ -57,18 +62,24 @@ fun LunarPhaseDetailsDialog(
                 .fillMaxWidth()
                 .clip(shape = RoundedCornerShape(size = 12.dp))
                 .background(color = MaterialTheme.colors.primaryVariant)
-                .padding(horizontal = 24.dp)
+                .padding(horizontal = 24.dp, vertical = 24.dp)
         ) {
             lunarPhaseDetails.getOrNull()?.let { phaseDetails ->
-                VerticalSpacer(spacing = 24.dp)
                 TodayLunarPhase(lunarPhaseDetails = phaseDetails)
 
-                VerticalSpacer(spacing = 24.dp)
-                Divider(color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f))
-                VerticalSpacer(spacing = 12.dp)
+                Divider(
+                    color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f),
+                    modifier = Modifier.padding(vertical = 16.dp)
+                )
+
+                NextMajorPhaseDetails(phaseDetails.nextPhaseDetails)
+
+                Divider(
+                    color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f),
+                    modifier = Modifier.padding(vertical = 16.dp)
+                )
 
                 LunarRiseAndSetDetails(lunarPhaseDetails = phaseDetails)
-                VerticalSpacer(spacing = 24.dp)
             }
         }
     }
@@ -142,16 +153,109 @@ private fun TodayLunarMoonPhaseDetails(
 }
 
 @Composable
+private fun NextMajorPhaseDetails(
+    nextPhaseDetails: NextPhaseDetails,
+    textColor: Color = MaterialTheme.colors.onBackground,
+) {
+    Column {
+        Text(
+            text = "Upcoming Phases",
+            style = TextStyle(
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.2.sp,
+            ),
+        )
+
+        VerticalSpacer(spacing = 12.dp)
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(intrinsicSize = IntrinsicSize.Min)
+        ) {
+            Box(modifier = Modifier.weight(weight = 1f)) {
+                NextSingleMajorPhaseDetails(
+                    illumination = 0.0,
+                    localDateTime = nextPhaseDetails.newMoon
+                )
+            }
+
+            HorizontalSpacer(spacing = 12.dp)
+
+            Box(modifier = Modifier.weight(weight = 1f)) {
+                NextSingleMajorPhaseDetails(
+                    illumination = 100.0,
+                    localDateTime = nextPhaseDetails.fullMoon
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NextSingleMajorPhaseDetails(
+    illumination: Double,
+    localDateTime: LocalDateTime?,
+    textColor: Color = MaterialTheme.colors.onBackground,
+) {
+    val date = localDateTime?.inShortReadableFormat(shortMonthName = true) ?: "-"
+
+    val time = if (localDateTime != null) {
+        val javaInstant = localDateTime.toInstant(TimeZone.currentSystemDefault()).toJavaInstant()
+        SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date.from(javaInstant))
+    } else "-"
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        LunarPhaseMoonIcon(
+            phaseAngle = 0.0,
+            illumination = illumination,
+            moonSize = 40.dp
+        )
+
+        HorizontalSpacer(spacing = 8.dp)
+
+        Column(
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = date,
+                style = TextStyle(
+                    color = textColor,
+                    fontSize = 14.sp,
+                    letterSpacing = 1.2.sp,
+                ),
+            )
+
+            VerticalSpacer(spacing = 4.dp)
+
+            Text(
+                text = time,
+                style = TextStyle(
+                    color = textColor,
+                    fontSize = 11.sp,
+                    letterSpacing = 1.2.sp,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
 fun LunarRiseAndSetDetails(
     lunarPhaseDetails: LunarPhaseDetails,
 ) {
     RiseAndSetHeaders()
-    VerticalSpacer(spacing = 12.dp)
+    VerticalSpacer(spacing = 16.dp)
     RiseTimeDetails(
         moonRiseDateTime = lunarPhaseDetails.moonRiseAndSetDetails.riseDateTime,
         sunRiseDateTime = lunarPhaseDetails.sunRiseAndSetDetails.riseDateTime
     )
-    VerticalSpacer(spacing = 2.dp)
+    VerticalSpacer(spacing = 4.dp)
     SetTimeDetails(
         moonSetDateTime = lunarPhaseDetails.moonRiseAndSetDetails.setDateTime,
         sunSetDateTime = lunarPhaseDetails.sunRiseAndSetDetails.setDateTime
@@ -224,7 +328,7 @@ private fun RiseAndSetTime(
         text = time,
         style = TextStyle(
             color = textColor,
-            fontSize = 16.sp,
+            fontSize = 14.sp,
             letterSpacing = 1.2.sp,
         ),
     )

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/dialogs/LunarPhaseDetailsDialog.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/dialogs/LunarPhaseDetailsDialog.kt
@@ -1,0 +1,250 @@
+package dev.mslalith.focuslauncher.ui.views.dialogs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import dev.mslalith.focuslauncher.data.model.LunarPhaseDetails
+import dev.mslalith.focuslauncher.data.model.getOrNull
+import dev.mslalith.focuslauncher.extensions.FillSpacer
+import dev.mslalith.focuslauncher.extensions.HorizontalSpacer
+import dev.mslalith.focuslauncher.extensions.VerticalSpacer
+import dev.mslalith.focuslauncher.extensions.asPercent
+import dev.mslalith.focuslauncher.extensions.limitDecimals
+import dev.mslalith.focuslauncher.ui.viewmodels.WidgetsViewModel
+import dev.mslalith.focuslauncher.ui.views.widgets.LunarPhaseMoonIcon
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toJavaInstant
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun LunarPhaseDetailsDialog(
+    widgetsViewModel: WidgetsViewModel,
+    onClose: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onClose
+    ) {
+        val lunarPhaseDetails by widgetsViewModel.lunarPhaseDetailsStateFlow.collectAsState()
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(shape = RoundedCornerShape(size = 12.dp))
+                .background(color = MaterialTheme.colors.primaryVariant)
+                .padding(horizontal = 24.dp)
+        ) {
+            lunarPhaseDetails.getOrNull()?.let { phaseDetails ->
+                VerticalSpacer(spacing = 24.dp)
+                TodayLunarPhase(lunarPhaseDetails = phaseDetails)
+
+                VerticalSpacer(spacing = 24.dp)
+                Divider(color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f))
+                VerticalSpacer(spacing = 12.dp)
+
+                LunarRiseAndSetDetails(lunarPhaseDetails = phaseDetails)
+                VerticalSpacer(spacing = 24.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TodayLunarPhase(
+    lunarPhaseDetails: LunarPhaseDetails,
+) {
+    BoxWithConstraints {
+        val width = maxWidth
+        Row(modifier = Modifier.fillMaxWidth()) {
+            TodayLunarMoonIconAndPhase(
+                lunarPhaseDetails = lunarPhaseDetails,
+                moonSize = width
+            )
+            HorizontalSpacer(spacing = 12.dp)
+            TodayLunarMoonPhaseDetails(lunarPhaseDetails = lunarPhaseDetails)
+        }
+    }
+}
+
+@Composable
+private fun TodayLunarMoonIconAndPhase(
+    lunarPhaseDetails: LunarPhaseDetails,
+    moonSize: Dp,
+) {
+    Column {
+        LunarPhaseMoonIcon(
+            lunarPhaseDetails = lunarPhaseDetails,
+            moonSize = moonSize * 0.3f
+        )
+    }
+}
+
+@Composable
+private fun TodayLunarMoonPhaseDetails(
+    lunarPhaseDetails: LunarPhaseDetails,
+    textColor: Color = MaterialTheme.colors.onBackground,
+) {
+    Column {
+        Text(
+            text = lunarPhaseDetails.lunarPhase.phaseName,
+            style = TextStyle(
+                color = textColor,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.2.sp,
+            ),
+        )
+        VerticalSpacer(spacing = 8.dp)
+        Text(
+            text = "Illumination: ${lunarPhaseDetails.illumination.times(100).asPercent(precision = 3)}",
+            style = TextStyle(
+                color = textColor,
+                fontSize = 14.sp,
+                letterSpacing = 1.2.sp,
+            ),
+        )
+        VerticalSpacer(spacing = 4.dp)
+        Text(
+            text = "Angle: ${lunarPhaseDetails.phaseAngle.limitDecimals(precision = 2)}",
+            style = TextStyle(
+                color = textColor,
+                fontSize = 14.sp,
+                letterSpacing = 1.2.sp,
+            ),
+        )
+    }
+}
+
+@Composable
+fun LunarRiseAndSetDetails(
+    lunarPhaseDetails: LunarPhaseDetails,
+) {
+    RiseAndSetHeaders()
+    VerticalSpacer(spacing = 12.dp)
+    RiseTimeDetails(
+        moonRiseDateTime = lunarPhaseDetails.moonRiseAndSetDetails.riseDateTime,
+        sunRiseDateTime = lunarPhaseDetails.sunRiseAndSetDetails.riseDateTime
+    )
+    VerticalSpacer(spacing = 2.dp)
+    SetTimeDetails(
+        moonSetDateTime = lunarPhaseDetails.moonRiseAndSetDetails.setDateTime,
+        sunSetDateTime = lunarPhaseDetails.sunRiseAndSetDetails.setDateTime
+    )
+}
+
+@Composable
+private fun RiseAndSetHeaders(
+    textColor: Color = MaterialTheme.colors.onBackground,
+) {
+    Row {
+        Text(
+            text = "Moon",
+            style = TextStyle(
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.2.sp,
+            ),
+        )
+        FillSpacer()
+        Text(
+            text = "Sun",
+            style = TextStyle(
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.2.sp,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun RiseTimeDetails(
+    moonRiseDateTime: LocalDateTime?,
+    sunRiseDateTime: LocalDateTime?,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        RiseAndSetTime(localDateTime = moonRiseDateTime)
+        RiseAndSetIndicator(text = "Rise")
+        RiseAndSetTime(localDateTime = sunRiseDateTime)
+    }
+}
+
+@Composable
+private fun SetTimeDetails(
+    moonSetDateTime: LocalDateTime?,
+    sunSetDateTime: LocalDateTime?,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        RiseAndSetTime(localDateTime = moonSetDateTime)
+        RiseAndSetIndicator(text = "Set")
+        RiseAndSetTime(localDateTime = sunSetDateTime)
+    }
+}
+
+@Composable
+private fun RiseAndSetTime(
+    modifier: Modifier = Modifier,
+    localDateTime: LocalDateTime?,
+    textColor: Color = MaterialTheme.colors.onBackground,
+) {
+    val time = if (localDateTime != null) {
+        val javaInstant = localDateTime.toInstant(TimeZone.currentSystemDefault()).toJavaInstant()
+        SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date.from(javaInstant))
+    } else "-"
+    Text(
+        modifier = modifier,
+        text = time,
+        style = TextStyle(
+            color = textColor,
+            fontSize = 16.sp,
+            letterSpacing = 1.2.sp,
+        ),
+    )
+}
+
+@Composable
+private fun RowScope.RiseAndSetIndicator(
+    text: String,
+    textColor: Color = MaterialTheme.colors.onBackground,
+) {
+    Box(
+        modifier = Modifier.weight(weight = 1f),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            style = TextStyle(
+                color = textColor,
+                fontSize = 12.sp,
+                letterSpacing = 1.2.sp,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/dialogs/LunarPhaseDetailsDialog.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/dialogs/LunarPhaseDetailsDialog.kt
@@ -98,7 +98,8 @@ private fun TodayLunarMoonIconAndPhase(
 ) {
     Column {
         LunarPhaseMoonIcon(
-            lunarPhaseDetails = lunarPhaseDetails,
+            phaseAngle = lunarPhaseDetails.phaseAngle,
+            illumination = lunarPhaseDetails.illumination,
             moonSize = moonSize * 0.3f
         )
     }

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/shared/SearchField.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/shared/SearchField.kt
@@ -1,0 +1,82 @@
+package dev.mslalith.focuslauncher.ui.views.shared
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Clear
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SearchField(
+    modifier: Modifier = Modifier,
+    placeholder: String,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    paddingValues: PaddingValues = PaddingValues(horizontal = 24.dp, vertical = 12.dp)
+) {
+    val colors = MaterialTheme.colors
+
+    TextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(paddingValues = paddingValues),
+        value = query,
+        textStyle = TextStyle(color = colors.onBackground),
+        onValueChange = { onQueryChange(it) },
+        placeholder = {
+            Text(
+                text = placeholder,
+                style = TextStyle(color = colors.onBackground)
+            )
+        },
+        shape = MaterialTheme.shapes.small,
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            autoCorrect = false,
+            imeAction = ImeAction.Search
+        ),
+        colors = TextFieldDefaults.textFieldColors(
+            cursorColor = colors.onBackground,
+            backgroundColor = colors.primaryVariant,
+            focusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent
+        ),
+        leadingIcon = {
+            Icon(Icons.Rounded.Search, contentDescription = "Search")
+        },
+        trailingIcon = {
+            AnimatedVisibility(visible = query.isNotEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .clickable { onQueryChange("") }
+                        .padding(4.dp)
+                ) {
+                    Icon(
+                        Icons.Rounded.Clear,
+                        contentDescription = "Clear",
+                    )
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/widgets/LunarCalendar.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/widgets/LunarCalendar.kt
@@ -94,7 +94,8 @@ fun LunarCalendarContent(
         icon = {
             lunarPhaseDetails.getOrNull()?.let {
                 LunarPhaseMoonIcon(
-                    lunarPhaseDetails = it,
+                    phaseAngle = it.phaseAngle,
+                    illumination = it.illumination,
                     moonSize = iconSize,
                 )
             }
@@ -123,7 +124,8 @@ fun LunarCalendarContent(
 @Composable
 fun LunarPhaseMoonIcon(
     modifier: Modifier = Modifier,
-    lunarPhaseDetails: LunarPhaseDetails,
+    phaseAngle: Double,
+    illumination: Double,
     moonSize: Dp = 40.dp,
 ) {
     val illuminatedColor = Color(0xFFBCC1C5)
@@ -131,7 +133,7 @@ fun LunarPhaseMoonIcon(
     val moonSpotColor = Color(0xFF5B6876)
 
     val rotationDegrees by animateFloatAsState(
-        targetValue = when (lunarPhaseDetails.phaseAngle < 0) {
+        targetValue = when (phaseAngle < 0) {
             true -> 180f
             false -> 0f
         }
@@ -143,7 +145,7 @@ fun LunarPhaseMoonIcon(
         targetValue = lerp(
             start = startOffset,
             stop = endOffset,
-            fraction = lunarPhaseDetails.illumination.toFloat(),
+            fraction = illumination.toFloat(),
         )
     )
 

--- a/app/src/main/java/dev/mslalith/focuslauncher/ui/views/widgets/LunarCalendar.kt
+++ b/app/src/main/java/dev/mslalith/focuslauncher/ui/views/widgets/LunarCalendar.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateOffsetAsState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -47,6 +48,7 @@ fun LunarCalendar(
     height: Dp = 74.dp,
     iconSize: Dp = 40.dp,
     horizontalPadding: Dp = 0.dp,
+    onClick: (() -> Unit)? = null
 ) {
     val showLunarPhase by settingsViewModel.showLunarPhaseStateFlow.collectAsState()
     val showIlluminationPercent by settingsViewModel.showIlluminationPercentStateFlow.collectAsState()
@@ -67,6 +69,7 @@ fun LunarCalendar(
             height = height,
             iconSize = iconSize,
             horizontalPadding = horizontalPadding,
+            onClick = onClick
         )
     }
 }
@@ -81,10 +84,12 @@ fun LunarCalendarContent(
     height: Dp = 74.dp,
     iconSize: Dp = 40.dp,
     horizontalPadding: Dp = 0.dp,
+    onClick: (() -> Unit)? = null
 ) {
     ListItem(
         modifier = Modifier
             .height(height = height)
+            .clickable(enabled = onClick != null) { onClick?.invoke() }
             .padding(horizontal = horizontalPadding),
         icon = {
             lunarPhaseDetails.getOrNull()?.let {
@@ -116,7 +121,7 @@ fun LunarCalendarContent(
 }
 
 @Composable
-private fun LunarPhaseMoonIcon(
+fun LunarPhaseMoonIcon(
     modifier: Modifier = Modifier,
     lunarPhaseDetails: LunarPhaseDetails,
     moonSize: Dp = 40.dp,

--- a/buildSrc/src/main/kotlin/ConfigData.kt
+++ b/buildSrc/src/main/kotlin/ConfigData.kt
@@ -1,5 +1,5 @@
 object ConfigData {
-    const val MIN_SDK = 21
+    const val MIN_SDK = 26
     const val TARGET_SDK = 31
     const val BUILD_TOOLS = "30.0.3"
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -45,7 +45,6 @@ object Libs {
 
     const val accompanistPager = "com.google.accompanist:accompanist-pager:${Versions.ACCOMPANIST}"
     const val accompanistSystemUiController = "com.google.accompanist:accompanist-systemuicontroller:${Versions.ACCOMPANIST}"
-    const val accompanistInsets = "com.google.accompanist:accompanist-insets:${Versions.ACCOMPANIST}"
     const val accompanistFlowLayout = "com.google.accompanist:accompanist-flowlayout:${Versions.ACCOMPANIST}"
 
     const val thirdSunCalc = "org.shredzone.commons:commons-suncalc:${Versions.THIRD_SUNCALC}"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -20,14 +20,10 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
 
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments += mapOf(
-                    "room.schemaLocation" to "$projectDir/schemas",
-                    "room.incremental" to "true",
-                    "room.expandProjection" to "true"
-                )
-            }
+        ksp {
+            arg("room.schemaLocation", "$projectDir/schemas")
+            arg("room.incremental", "true")
+            arg("room.expandProjection", "true")
         }
     }
 

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/database/AppDatabase.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/database/AppDatabase.kt
@@ -4,10 +4,12 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import dev.mslalith.focuslauncher.data.database.dao.AppsDao
+import dev.mslalith.focuslauncher.data.database.dao.CitiesDao
 import dev.mslalith.focuslauncher.data.database.dao.FavoriteAppsDao
 import dev.mslalith.focuslauncher.data.database.dao.HiddenAppsDao
 import dev.mslalith.focuslauncher.data.database.dao.QuotesDao
 import dev.mslalith.focuslauncher.data.database.entities.AppRoom
+import dev.mslalith.focuslauncher.data.database.entities.CityRoom
 import dev.mslalith.focuslauncher.data.database.entities.FavoriteAppRoom
 import dev.mslalith.focuslauncher.data.database.entities.HiddenAppRoom
 import dev.mslalith.focuslauncher.data.database.entities.QuoteRoom
@@ -18,7 +20,8 @@ import dev.mslalith.focuslauncher.data.database.typeconverter.Converters
         AppRoom::class,
         FavoriteAppRoom::class,
         HiddenAppRoom::class,
-        QuoteRoom::class
+        QuoteRoom::class,
+        CityRoom::class
     ],
     version = 1,
     exportSchema = false
@@ -30,4 +33,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun favoriteAppsDao(): FavoriteAppsDao
     abstract fun hiddenAppsDao(): HiddenAppsDao
     abstract fun quotesDao(): QuotesDao
+    abstract fun citiesDao(): CitiesDao
 }

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/database/dao/CitiesDao.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/database/dao/CitiesDao.kt
@@ -6,13 +6,15 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import dev.mslalith.focuslauncher.data.database.entities.CityRoom
 import dev.mslalith.focuslauncher.data.utils.Constants
-import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CitiesDao {
 
-    @Query("SELECT * FROM ${Constants.Database.CITIES_TABLE_NAME}")
-    fun getCities(): Flow<List<CityRoom>>
+    @Query("SELECT * FROM ${Constants.Database.CITIES_TABLE_NAME} ORDER BY id")
+    suspend fun getAllCities(): List<CityRoom>
+
+    @Query("SELECT * FROM ${Constants.Database.CITIES_TABLE_NAME} WHERE name LIKE '%' || :query || '%' ORDER BY id")
+    suspend fun getCitiesByQuery(query: String): List<CityRoom>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCities(cities: List<CityRoom>)

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/database/dao/CitiesDao.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/database/dao/CitiesDao.kt
@@ -1,0 +1,19 @@
+package dev.mslalith.focuslauncher.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import dev.mslalith.focuslauncher.data.database.entities.CityRoom
+import dev.mslalith.focuslauncher.data.utils.Constants
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CitiesDao {
+
+    @Query("SELECT * FROM ${Constants.Database.CITIES_TABLE_NAME}")
+    fun getCities(): Flow<List<CityRoom>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCities(cities: List<CityRoom>)
+}

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/database/entities/CityRoom.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/database/entities/CityRoom.kt
@@ -1,0 +1,21 @@
+package dev.mslalith.focuslauncher.data.database.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import dev.mslalith.focuslauncher.data.utils.Constants
+
+@Entity(tableName = Constants.Database.CITIES_TABLE_NAME)
+data class CityRoom(
+    @PrimaryKey(autoGenerate = false)
+    val id: Int,
+    val name: String,
+    val stateId: Int,
+    val stateCode: String,
+    val stateName: String,
+    val countryId: Int,
+    val countryCode: String,
+    val countryName: String,
+    val latitude: String,
+    val longitude: String,
+    val wikiDataId: String?,
+)

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/NetworkModule.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/NetworkModule.kt
@@ -4,6 +4,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dev.mslalith.focuslauncher.data.network.api.PlacesApi
+import dev.mslalith.focuslauncher.data.network.api.PlacesApiImpl
 import dev.mslalith.focuslauncher.data.network.api.QuotesApi
 import dev.mslalith.focuslauncher.data.network.api.QuotesApiKtorImpl
 import io.ktor.client.HttpClient
@@ -42,4 +44,8 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideQuoteApi(httpClient: HttpClient): QuotesApi = QuotesApiKtorImpl(httpClient)
+
+    @Provides
+    @Singleton
+    fun providePlacesApi(httpClient: HttpClient): PlacesApi = PlacesApiImpl(httpClient)
 }

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/RepositoryModule.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/RepositoryModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dev.mslalith.focuslauncher.data.database.dao.AppsDao
+import dev.mslalith.focuslauncher.data.database.dao.CitiesDao
 import dev.mslalith.focuslauncher.data.database.dao.FavoriteAppsDao
 import dev.mslalith.focuslauncher.data.database.dao.HiddenAppsDao
 import dev.mslalith.focuslauncher.data.database.dao.QuotesDao
@@ -29,6 +30,7 @@ import dev.mslalith.focuslauncher.data.repository.settings.ClockSettingsRepo
 import dev.mslalith.focuslauncher.data.repository.settings.GeneralSettingsRepo
 import dev.mslalith.focuslauncher.data.repository.settings.LunarPhaseSettingsRepo
 import dev.mslalith.focuslauncher.data.repository.settings.QuotesSettingsRepo
+import dev.mslalith.focuslauncher.data.serializers.CityJsonParser
 import dev.mslalith.focuslauncher.data.utils.AppCoroutineDispatcher
 import javax.inject.Singleton
 
@@ -106,7 +108,7 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun providePlacesRepo(placesApi: PlacesApi) = PlacesRepo(placesApi = placesApi)
+    fun providePlacesRepo(placesApi: PlacesApi, citiesDao: CitiesDao) = PlacesRepo(placesApi, citiesDao)
 
     /**
      * Settings Repository providers
@@ -125,7 +127,10 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideLunarPhaseSettingsRepo(@SettingsProvider settingsDataStore: DataStore<Preferences>) = LunarPhaseSettingsRepo(settingsDataStore)
+    fun provideLunarPhaseSettingsRepo(
+        @SettingsProvider settingsDataStore: DataStore<Preferences>,
+        cityJsonParser: CityJsonParser,
+    ) = LunarPhaseSettingsRepo(settingsDataStore, cityJsonParser)
 
     @Provides
     @Singleton

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/RepositoryModule.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/RepositoryModule.kt
@@ -15,12 +15,14 @@ import dev.mslalith.focuslauncher.data.dto.FavoriteToRoomMapper
 import dev.mslalith.focuslauncher.data.dto.HiddenToRoomMapper
 import dev.mslalith.focuslauncher.data.dto.QuoteResponseToRoomMapper
 import dev.mslalith.focuslauncher.data.dto.QuoteToRoomMapper
+import dev.mslalith.focuslauncher.data.network.api.PlacesApi
 import dev.mslalith.focuslauncher.data.network.api.QuotesApi
 import dev.mslalith.focuslauncher.data.repository.AppDrawerRepo
 import dev.mslalith.focuslauncher.data.repository.ClockRepo
 import dev.mslalith.focuslauncher.data.repository.FavoritesRepo
 import dev.mslalith.focuslauncher.data.repository.HiddenAppsRepo
 import dev.mslalith.focuslauncher.data.repository.LunarPhaseDetailsRepo
+import dev.mslalith.focuslauncher.data.repository.PlacesRepo
 import dev.mslalith.focuslauncher.data.repository.QuotesRepo
 import dev.mslalith.focuslauncher.data.repository.settings.AppDrawerSettingsRepo
 import dev.mslalith.focuslauncher.data.repository.settings.ClockSettingsRepo
@@ -101,6 +103,10 @@ object RepositoryModule {
         quoteToRoomMapper = quoteToRoomMapper,
         quoteResponseToRoomMapper = quoteResponseToRoomMapper
     )
+
+    @Provides
+    @Singleton
+    fun providePlacesRepo(placesApi: PlacesApi) = PlacesRepo(placesApi = placesApi)
 
     /**
      * Settings Repository providers

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/RoomModule.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/RoomModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.mslalith.focuslauncher.data.database.AppDatabase
 import dev.mslalith.focuslauncher.data.database.dao.AppsDao
+import dev.mslalith.focuslauncher.data.database.dao.CitiesDao
 import dev.mslalith.focuslauncher.data.database.dao.FavoriteAppsDao
 import dev.mslalith.focuslauncher.data.database.dao.HiddenAppsDao
 import dev.mslalith.focuslauncher.data.database.dao.QuotesDao
@@ -42,4 +43,8 @@ object RoomModule {
     @Provides
     @Singleton
     fun provideQuotesDao(appDatabase: AppDatabase): QuotesDao = appDatabase.quotesDao()
+
+    @Provides
+    @Singleton
+    fun provideCitiesDao(appDatabase: AppDatabase): CitiesDao = appDatabase.citiesDao()
 }

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/SerializerModule.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/di/modules/SerializerModule.kt
@@ -1,0 +1,17 @@
+package dev.mslalith.focuslauncher.data.di.modules
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dev.mslalith.focuslauncher.data.serializers.CityJsonParser
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SerializerModule {
+
+    @Provides
+    @Singleton
+    fun provideCityJsonParser() = CityJsonParser()
+}

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/dto/places/CityMapper.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/dto/places/CityMapper.kt
@@ -1,0 +1,11 @@
+package dev.mslalith.focuslauncher.data.dto.places
+
+import dev.mslalith.focuslauncher.data.model.places.City
+import dev.mslalith.focuslauncher.data.network.entities.CityResponse
+
+fun CityResponse.toCity() = City(
+    id = id,
+    name = name,
+    latitude = latitude.toDouble(),
+    longitude = longitude.toDouble()
+)

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/dto/places/CityMapper.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/dto/places/CityMapper.kt
@@ -1,9 +1,24 @@
 package dev.mslalith.focuslauncher.data.dto.places
 
+import dev.mslalith.focuslauncher.data.database.entities.CityRoom
 import dev.mslalith.focuslauncher.data.model.places.City
 import dev.mslalith.focuslauncher.data.network.entities.CityResponse
 
-fun CityResponse.toCity() = City(
+fun CityResponse.toCityRoom() = CityRoom(
+    id = id,
+    name = name,
+    stateId = stateId,
+    stateCode = stateCode,
+    stateName = stateName,
+    countryId = countryId,
+    countryCode = countryCode,
+    countryName = countryName,
+    latitude = latitude,
+    longitude = longitude,
+    wikiDataId = wikiDataId
+)
+
+fun CityRoom.toCity() = City(
     id = id,
     name = name,
     latitude = latitude.toDouble(),

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/extensions/UtilityExtensions.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/extensions/UtilityExtensions.kt
@@ -1,7 +1,9 @@
-package dev.mslalith.focuslauncher.data.utils
+package dev.mslalith.focuslauncher.data.extensions
 
 import android.os.Handler
 import android.os.Looper
+import kotlinx.datetime.LocalDateTime
+import java.time.ZonedDateTime
 
 fun runAfter(delayMillis: Long, action: () -> Unit) = Handler(Looper.getMainLooper()).postDelayed(action, delayMillis)
 
@@ -16,4 +18,11 @@ fun waitAndRunAfter(
         delayMillis = waitTimeMillis,
         action = action,
     )
+}
+
+fun ZonedDateTime.toKotlinxLocalDateTime() = try {
+    val isoString = this.toString().substringBefore(delimiter = "+")
+    LocalDateTime.parse(isoString)
+} catch (ex: Exception) {
+    null
 }

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/model/LunarPhase.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/model/LunarPhase.kt
@@ -13,10 +13,17 @@ import dev.mslalith.focuslauncher.data.model.LunarPhaseDirection.NEW_TO_FULL
 import kotlinx.datetime.LocalDateTime
 import org.shredzone.commons.suncalc.MoonPhase
 
+data class RiseAndSetDetails(
+    val riseDateTime: LocalDateTime?,
+    val setDateTime: LocalDateTime?
+)
+
 data class LunarPhaseDetails(
     val lunarPhase: LunarPhase,
     val illumination: Double,
     val phaseAngle: Double,
+    val moonRiseAndSetDetails: RiseAndSetDetails,
+    val sunRiseAndSetDetails: RiseAndSetDetails
 ) {
     val direction: LunarPhaseDirection
         get() = when (lunarPhase) {

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/model/LunarPhase.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/model/LunarPhase.kt
@@ -18,10 +18,16 @@ data class RiseAndSetDetails(
     val setDateTime: LocalDateTime?
 )
 
+data class NextPhaseDetails(
+    val newMoon: LocalDateTime?,
+    val fullMoon: LocalDateTime?
+)
+
 data class LunarPhaseDetails(
     val lunarPhase: LunarPhase,
     val illumination: Double,
     val phaseAngle: Double,
+    val nextPhaseDetails: NextPhaseDetails,
     val moonRiseAndSetDetails: RiseAndSetDetails,
     val sunRiseAndSetDetails: RiseAndSetDetails
 ) {

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/model/places/City.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/model/places/City.kt
@@ -1,0 +1,11 @@
+package dev.mslalith.focuslauncher.data.model.places
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class City(
+    val id: Int,
+    val name: String,
+    val latitude: Double,
+    val longitude: Double
+)

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/network/api/PlacesApi.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/network/api/PlacesApi.kt
@@ -1,0 +1,32 @@
+package dev.mslalith.focuslauncher.data.network.api
+
+import dev.mslalith.focuslauncher.data.network.entities.CityResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import javax.inject.Inject
+
+interface PlacesApi {
+    suspend fun getCities(): List<CityResponse>
+}
+
+internal class PlacesApiImpl @Inject constructor(
+    private val httpClient: HttpClient,
+) : PlacesApi {
+
+    private val baseUrl = "https://raw.githubusercontent.com/dr5hn/countries-states-cities-database/master"
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override suspend fun getCities(): List<CityResponse> {
+        val responseString = httpClient.get("$baseUrl/cities.json").bodyAsChannel()
+        return Json.decodeFromStream(
+            deserializer = ListSerializer(elementSerializer = CityResponse.serializer()),
+            stream = responseString.toInputStream()
+        )
+    }
+}

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/network/entities/CityResponse.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/network/entities/CityResponse.kt
@@ -1,0 +1,30 @@
+package dev.mslalith.focuslauncher.data.network.entities
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CityResponse(
+    @SerialName(value = "id")
+    val id: Int,
+    @SerialName("name")
+    val name: String,
+    @SerialName("state_id")
+    val stateId: Int,
+    @SerialName("state_code")
+    val stateCode: String,
+    @SerialName("state_name")
+    val stateName: String,
+    @SerialName("country_id")
+    val countryId: Int,
+    @SerialName("country_code")
+    val countryCode: String,
+    @SerialName("country_name")
+    val countryName: String,
+    @SerialName("latitude")
+    val latitude: String,
+    @SerialName("longitude")
+    val longitude: String,
+    @SerialName("wikiDataId")
+    val wikiDataId: String?,
+)

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepo.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepo.kt
@@ -9,6 +9,7 @@ import dev.mslalith.focuslauncher.data.model.State
 import dev.mslalith.focuslauncher.data.model.UpcomingLunarPhase
 import dev.mslalith.focuslauncher.data.model.toLunarPhase
 import dev.mslalith.focuslauncher.data.extensions.toKotlinxLocalDateTime
+import dev.mslalith.focuslauncher.data.model.NextPhaseDetails
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -50,6 +51,8 @@ class LunarPhaseDetailsRepo @Inject constructor() {
 
     @VisibleForTesting
     fun findLunarPhaseDetails(instant: Instant): LunarPhaseDetails {
+        val nextNewMoon = MoonPhase.compute().phase(MoonPhase.Phase.NEW_MOON).execute()
+        val nextFullMoon = MoonPhase.compute().phase(MoonPhase.Phase.FULL_MOON).execute()
         val moonIllumination = MoonIllumination.compute().on(instant.toJavaInstant()).execute()
         val moonTimes = MoonTimes.compute().today().at(17.6868, 83.2185).execute()
         val sunTimes = SunTimes.compute().today().at(17.6868, 83.2185).execute()
@@ -57,6 +60,10 @@ class LunarPhaseDetailsRepo @Inject constructor() {
             lunarPhase = moonIllumination.closestPhase.toLunarPhase(),
             illumination = moonIllumination.fraction,
             phaseAngle = moonIllumination.phase,
+            nextPhaseDetails = NextPhaseDetails(
+                newMoon = nextNewMoon.time?.toKotlinxLocalDateTime(),
+                fullMoon = nextFullMoon.time?.toKotlinxLocalDateTime()
+            ),
             moonRiseAndSetDetails = RiseAndSetDetails(
                 riseDateTime = moonTimes.rise?.toKotlinxLocalDateTime(),
                 setDateTime = moonTimes.set?.toKotlinxLocalDateTime()

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepo.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepo.kt
@@ -9,6 +9,7 @@ import dev.mslalith.focuslauncher.data.model.NextPhaseDetails
 import dev.mslalith.focuslauncher.data.model.RiseAndSetDetails
 import dev.mslalith.focuslauncher.data.model.State
 import dev.mslalith.focuslauncher.data.model.UpcomingLunarPhase
+import dev.mslalith.focuslauncher.data.model.places.City
 import dev.mslalith.focuslauncher.data.model.toLunarPhase
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,11 +36,11 @@ class LunarPhaseDetailsRepo @Inject constructor() {
     val upcomingLunarPhaseStateFlow: StateFlow<State<UpcomingLunarPhase>>
         get() = _upcomingLunarPhaseStateFlow
 
-    suspend fun refreshLunarPhaseDetails(instant: Instant) {
+    suspend fun refreshLunarPhaseDetails(instant: Instant, city: City) {
         val delayInMillis = Random.nextInt(from = 8, until = 17) * 100L
         delay(delayInMillis)
 
-        val lunarPhaseDetails = findLunarPhaseDetails(instant)
+        val lunarPhaseDetails = findLunarPhaseDetails(instant, city)
         updateStateFlowsWith(lunarPhaseDetails)
     }
 
@@ -50,12 +51,12 @@ class LunarPhaseDetailsRepo @Inject constructor() {
     }
 
     @VisibleForTesting
-    fun findLunarPhaseDetails(instant: Instant): LunarPhaseDetails {
+    fun findLunarPhaseDetails(instant: Instant, city: City): LunarPhaseDetails {
         val nextNewMoon = MoonPhase.compute().phase(MoonPhase.Phase.NEW_MOON).execute()
         val nextFullMoon = MoonPhase.compute().phase(MoonPhase.Phase.FULL_MOON).execute()
         val moonIllumination = MoonIllumination.compute().on(instant.toJavaInstant()).execute()
-        val moonTimes = MoonTimes.compute().today().at(17.6868, 83.2185).execute()
-        val sunTimes = SunTimes.compute().today().at(17.6868, 83.2185).execute()
+        val moonTimes = MoonTimes.compute().today().at(city.latitude, city.longitude).execute()
+        val sunTimes = SunTimes.compute().today().at(city.latitude, city.longitude).execute()
         return LunarPhaseDetails(
             lunarPhase = moonIllumination.closestPhase.toLunarPhase(),
             illumination = moonIllumination.fraction,

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepo.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepo.kt
@@ -1,15 +1,15 @@
 package dev.mslalith.focuslauncher.data.repository
 
 import androidx.annotation.VisibleForTesting
+import dev.mslalith.focuslauncher.data.extensions.toKotlinxLocalDateTime
 import dev.mslalith.focuslauncher.data.model.LunarPhase
 import dev.mslalith.focuslauncher.data.model.LunarPhaseDetails
 import dev.mslalith.focuslauncher.data.model.LunarPhaseDirection
+import dev.mslalith.focuslauncher.data.model.NextPhaseDetails
 import dev.mslalith.focuslauncher.data.model.RiseAndSetDetails
 import dev.mslalith.focuslauncher.data.model.State
 import dev.mslalith.focuslauncher.data.model.UpcomingLunarPhase
 import dev.mslalith.focuslauncher.data.model.toLunarPhase
-import dev.mslalith.focuslauncher.data.extensions.toKotlinxLocalDateTime
-import dev.mslalith.focuslauncher.data.model.NextPhaseDetails
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/repository/PlacesRepo.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/repository/PlacesRepo.kt
@@ -1,0 +1,20 @@
+package dev.mslalith.focuslauncher.data.repository
+
+import dev.mslalith.focuslauncher.data.dto.places.toCity
+import dev.mslalith.focuslauncher.data.model.places.City
+import dev.mslalith.focuslauncher.data.network.api.PlacesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+class PlacesRepo @Inject constructor(
+    private val placesApi: PlacesApi
+) {
+    private val _citiesStateFlow = MutableStateFlow<List<City>>(emptyList())
+    val citiesStateFlow: StateFlow<List<City>>
+        get() = _citiesStateFlow
+
+    suspend fun fetchCities() {
+        _citiesStateFlow.value = placesApi.getCities().map { it.toCity() }
+    }
+}

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/repository/PlacesRepo.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/repository/PlacesRepo.kt
@@ -4,18 +4,16 @@ import dev.mslalith.focuslauncher.data.database.dao.CitiesDao
 import dev.mslalith.focuslauncher.data.dto.places.toCity
 import dev.mslalith.focuslauncher.data.dto.places.toCityRoom
 import dev.mslalith.focuslauncher.data.network.api.PlacesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
 
 class PlacesRepo @Inject constructor(
     private val placesApi: PlacesApi,
     private val citiesDao: CitiesDao
 ) {
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val citiesFlow = citiesDao.getCities().mapLatest { cities ->
-        cities.map { it.toCity() }
-    }
+
+    suspend fun getAllCities() = citiesDao.getAllCities().map { it.toCity() }
+
+    suspend fun getCitiesByQuery(query: String) = citiesDao.getCitiesByQuery(query).map { it.toCity() }
 
     suspend fun fetchCities() {
         val cities = placesApi.getCities()

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/repository/settings/LunarPhaseSettingsRepo.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/repository/settings/LunarPhaseSettingsRepo.kt
@@ -7,17 +7,18 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import dev.mslalith.focuslauncher.data.di.modules.SettingsProvider
 import dev.mslalith.focuslauncher.data.model.places.City
+import dev.mslalith.focuslauncher.data.serializers.CityJsonParser
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_CURRENT_PLACE
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_SHOW_ILLUMINATION_PERCENT
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_SHOW_LUNAR_PHASE
 import dev.mslalith.focuslauncher.data.utils.Constants.Defaults.Settings.LunarPhase.DEFAULT_SHOW_UPCOMING_PHASE_DETAILS
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 class LunarPhaseSettingsRepo @Inject constructor(
     @SettingsProvider private val settingsDataStore: DataStore<Preferences>,
+    private val cityJsonParser: CityJsonParser
 ) {
 
     val showLunarPhaseFlow: Flow<Boolean>
@@ -37,8 +38,8 @@ class LunarPhaseSettingsRepo @Inject constructor(
 
     val currentPlaceFlow: Flow<City>
         get() = settingsDataStore.data.map {
-            val string = it[PREFERENCES_CURRENT_PLACE] ?: return@map DEFAULT_CURRENT_PLACE
-            Json.decodeFromString(City.serializer(), string)
+            val json = it[PREFERENCES_CURRENT_PLACE] ?: return@map DEFAULT_CURRENT_PLACE
+            cityJsonParser.fromJson(json)
         }
 
     suspend fun toggleShowLunarPhase() = toggleData(
@@ -58,7 +59,7 @@ class LunarPhaseSettingsRepo @Inject constructor(
 
     suspend fun updatePlace(city: City) {
         settingsDataStore.edit {
-            it[PREFERENCES_CURRENT_PLACE] = Json.encodeToString(City.serializer(), city)
+            it[PREFERENCES_CURRENT_PLACE] = cityJsonParser.toJson(city)
         }
     }
 

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/serializers/JsonParser.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/serializers/JsonParser.kt
@@ -1,0 +1,14 @@
+package dev.mslalith.focuslauncher.data.serializers
+
+import dev.mslalith.focuslauncher.data.model.places.City
+import kotlinx.serialization.json.Json
+
+interface JsonParser<T> {
+    fun fromJson(json: String): T
+    fun toJson(data: T): String
+}
+
+class CityJsonParser : JsonParser<City> {
+    override fun fromJson(json: String): City = Json.decodeFromString(City.serializer(), json)
+    override fun toJson(data: City): String = Json.encodeToString(City.serializer(), data)
+}

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/utils/Constants.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/utils/Constants.kt
@@ -16,6 +16,7 @@ object Constants {
         const val FAVORITE_APPS_TABLE_NAME = "favorites_apps"
         const val HIDDEN_APPS_TABLE_NAME = "hidden_apps"
         const val QUOTES_TABLE_NAME = "quotes"
+        const val CITIES_TABLE_NAME = "cities"
     }
 
     object Defaults {

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/utils/Constants.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/utils/Constants.kt
@@ -2,6 +2,7 @@ package dev.mslalith.focuslauncher.data.utils
 
 import dev.mslalith.focuslauncher.data.model.AppDrawerViewType
 import dev.mslalith.focuslauncher.data.model.ClockAlignment
+import dev.mslalith.focuslauncher.data.model.places.City
 
 object Constants {
     object DataStore {
@@ -48,6 +49,12 @@ object Constants {
                 const val DEFAULT_SHOW_LUNAR_PHASE = false
                 const val DEFAULT_SHOW_ILLUMINATION_PERCENT = false
                 const val DEFAULT_SHOW_UPCOMING_PHASE_DETAILS = true
+                val DEFAULT_CURRENT_PLACE = City(
+                    id = -1,
+                    name = "-",
+                    latitude = 0.0,
+                    longitude = 0.0
+                )
             }
 
             object Quotes {

--- a/data/src/main/java/dev/mslalith/focuslauncher/data/utils/UpdateManager.kt
+++ b/data/src/main/java/dev/mslalith/focuslauncher/data/utils/UpdateManager.kt
@@ -10,6 +10,7 @@ import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallErrorCode
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
+import dev.mslalith.focuslauncher.data.extensions.waitAndRunAfter
 import dev.mslalith.focuslauncher.data.utils.AppUpdateState.CheckForUpdates
 import dev.mslalith.focuslauncher.data.utils.AppUpdateState.CheckingForUpdates
 import dev.mslalith.focuslauncher.data.utils.AppUpdateState.DownloadFailed

--- a/data/src/test/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepoTest.kt
+++ b/data/src/test/java/dev/mslalith/focuslauncher/data/repository/LunarPhaseDetailsRepoTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.testIn
 import com.google.common.truth.Truth.assertThat
 import dev.mslalith.focuslauncher.androidtest.shared.awaitItemAndCancel
 import dev.mslalith.focuslauncher.data.model.State
+import dev.mslalith.focuslauncher.data.model.places.City
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -17,6 +18,13 @@ import kotlin.time.Duration.Companion.seconds
 class LunarPhaseDetailsRepoTest {
 
     private lateinit var lunarPhaseDetailsRepo: LunarPhaseDetailsRepo
+
+    private val city = City(
+        id = -1,
+        name = "Test",
+        latitude = 34.345345,
+        longitude = 65.452342
+    )
 
     @Before
     fun setUp() {
@@ -44,9 +52,9 @@ class LunarPhaseDetailsRepoTest {
         assertThat(lunarPhaseDetails).isInstanceOf(State.Error::class.java)
 
         instants.forEach { instant ->
-            lunarPhaseDetailsRepo.refreshLunarPhaseDetails(instant)
+            lunarPhaseDetailsRepo.refreshLunarPhaseDetails(instant, city)
             lunarPhaseDetails = lunarPhaseDetailsRepo.lunarPhaseDetailsStateFlow.testIn(this).awaitItemAndCancel()
-            val actualLunarPhaseDetails = lunarPhaseDetailsRepo.findLunarPhaseDetails(instant)
+            val actualLunarPhaseDetails = lunarPhaseDetailsRepo.findLunarPhaseDetails(instant, city)
 
             val lunarPhase = (lunarPhaseDetails as State.Success).value.lunarPhase
             assertThat(lunarPhase).isEqualTo(actualLunarPhaseDetails.lunarPhase)
@@ -61,9 +69,9 @@ class LunarPhaseDetailsRepoTest {
         assertThat(lunarPhaseDetails).isInstanceOf(State.Error::class.java)
 
         instants.forEach { instant ->
-            lunarPhaseDetailsRepo.refreshLunarPhaseDetails(instant)
+            lunarPhaseDetailsRepo.refreshLunarPhaseDetails(instant, city)
             lunarPhaseDetails = lunarPhaseDetailsRepo.lunarPhaseDetailsStateFlow.testIn(this).awaitItemAndCancel()
-            val actualLunarPhaseDetails = lunarPhaseDetailsRepo.findLunarPhaseDetails(instant)
+            val actualLunarPhaseDetails = lunarPhaseDetailsRepo.findLunarPhaseDetails(instant, city)
 
             val lunarPhase = (lunarPhaseDetails as State.Success).value.lunarPhase
             assertThat(lunarPhase).isEqualTo(actualLunarPhaseDetails.lunarPhase)

--- a/data/src/test/java/dev/mslalith/focuslauncher/data/repository/settings/LunarPhaseSettingsRepoTest.kt
+++ b/data/src/test/java/dev/mslalith/focuslauncher/data/repository/settings/LunarPhaseSettingsRepoTest.kt
@@ -2,6 +2,7 @@ package dev.mslalith.focuslauncher.data.repository.settings
 
 import com.google.common.truth.Truth.assertThat
 import dev.mslalith.focuslauncher.androidtest.shared.DataStoreTest
+import dev.mslalith.focuslauncher.data.serializers.CityJsonParser
 import dev.mslalith.focuslauncher.data.utils.Constants
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -12,7 +13,12 @@ import org.robolectric.RobolectricTestRunner
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class LunarPhaseSettingsRepoTest : DataStoreTest<LunarPhaseSettingsRepo>(
-    setupRepo = { LunarPhaseSettingsRepo(it) }
+    setupRepo = { dataStore ->
+        LunarPhaseSettingsRepo(
+            settingsDataStore = dataStore,
+            cityJsonParser = CityJsonParser()
+        )
+    }
 ) {
 
     @Test


### PR DESCRIPTION
Lunar Phase information will vary with the location. For this info to be accurate, we need location data (latitude, longitude).
The reason to add this is to avoid Location permission since this will be more like a one time setup. So, an option to select the place was given under Lunar Phase widget settings