### PR TITLE
fix: Sentry crash fixes

### DIFF
--- a/core/launcherapps/src/main/kotlin/dev/mslalith/focuslauncher/core/launcherapps/parser/IconPackXmlParser.kt
+++ b/core/launcherapps/src/main/kotlin/dev/mslalith/focuslauncher/core/launcherapps/parser/IconPackXmlParser.kt
@@ -41,13 +41,13 @@ internal class IconPackXmlParser(
         parseAppFilterXML()
     }
 
-    fun drawableFor(componentName: String): Drawable? {
+    fun drawableFor(componentName: String): Drawable? = runCatching {
         val set = iconPackToDrawablesMap[componentName]
         if (set.isNullOrEmpty()) return null
         val drawableInfo = set.firstOrNull { it is CalendarDrawableInfo } ?: set.first()
         @Suppress("DEPRECATION")
         return iconPackResources?.getDrawable(drawableInfo.getDrawableResId())
-    }
+    }.getOrNull()
 
     @SuppressLint("DiscouragedApi")
     @IgnoreNestedBlockDepth

--- a/feature/homepage/src/main/kotlin/dev/mslalith/focuslauncher/feature/homepage/HomePage.kt
+++ b/feature/homepage/src/main/kotlin/dev/mslalith/focuslauncher/feature/homepage/HomePage.kt
@@ -46,8 +46,10 @@ fun HomePage(
 
 
     fun openClockApp() {
-        val intent = Intent(AlarmClock.ACTION_SHOW_ALARMS)
-        context.startActivity(intent)
+        runCatching {
+            val intent = Intent(AlarmClock.ACTION_SHOW_ALARMS)
+            context.startActivity(intent)
+        }
     }
 
     HomePage(


### PR DESCRIPTION
- [x] Crash on click of Clock (ActivityNotFoundException)
- [x] Crash when parsing custom Icon Pack (Resource.NotFoundException)